### PR TITLE
Fix behaviour implementors lookup (OTP23 required)

### DIFF
--- a/lib/escript_testbed/behaviours.ex
+++ b/lib/escript_testbed/behaviours.ex
@@ -1,0 +1,34 @@
+defmodule EscriptTestbed.Behaviours do
+  def modules_belonging_to_namespace(namespace)
+      when is_binary(namespace) do
+    :code.all_available()
+    |> Enum.filter(fn {name, _file, _loaded} ->
+      String.starts_with?(to_string(name), "Elixir." <> namespace)
+    end)
+    |> Enum.map(fn {name, _, _} ->
+      name |> List.to_atom()
+    end)
+  end
+
+  def ensure_all_modules_loaded(namespace)
+      when is_binary(namespace) do
+    modules_belonging_to_namespace(namespace)
+    |> :code.ensure_modules_loaded()
+  end
+
+  def behaviours(mod)
+      when is_atom(mod) do
+    # Convert resulting list to [] if list of behaviours is nil
+    mod.module_info
+    |> get_in([:attributes, :behaviour])
+    |> List.wrap()
+  end
+
+  def implementors(namespace, behaviour)
+      when is_binary(namespace) and is_atom(behaviour) do
+    ensure_all_modules_loaded(namespace)
+
+    modules_belonging_to_namespace(namespace)
+    |> Enum.filter(&(behaviour in behaviours(&1)))
+  end
+end

--- a/lib/escript_testbed/cli.ex
+++ b/lib/escript_testbed/cli.ex
@@ -4,7 +4,7 @@ defmodule EscriptTestbed.CLI do
   Execute `./escript_testbed help` for details.
   """
 
-  alias EscriptTestbed.Scenario
+  alias EscriptTestbed.{Behaviours, Scenario}
 
   @command_aliases %{
     "s" => "sync",
@@ -72,7 +72,7 @@ defmodule EscriptTestbed.CLI do
   end
 
   defp execute_command(:list, _) do
-    all_scenarios = available_modules_with_behaviour(Scenario)
+    all_scenarios = Behaviours.implementors("EscriptTestbed", Scenario)
 
     if Enum.empty?(all_scenarios) do
       IO.puts("No scenarios available at this time")
@@ -86,9 +86,9 @@ defmodule EscriptTestbed.CLI do
   end
 
   defp cli_param_to_scenario(term) do
-    Scenario
-    |> available_modules_with_behaviour()
-    |> Enum.find(& scenario_to_cli_param(&1) == term)
+    "EscriptTestbed"
+    |> Behaviours.implementors(Scenario)
+    |> Enum.find(&(scenario_to_cli_param(&1) == term))
   end
 
   defp scenario_to_cli_param(module) do
@@ -98,14 +98,5 @@ defmodule EscriptTestbed.CLI do
     |> String.replace("Scenarios.", "")
     |> String.replace(".", "")
     |> Macro.underscore()
-  end
-
-  defp available_modules_with_behaviour(behaviour) do
-    for {module, _} <- :code.all_loaded(),
-        behaviour in (module.module_info(:attributes)
-                       |> Keyword.get_values(:behaviour)
-                       |> List.flatten()) do
-      module
-    end
   end
 end


### PR DESCRIPTION
Utilize OTP23's `:code.all_available()` API to locate modules. This fixes the problem of the project not being able to find the implementors of a `Behaviour` both in IEx and Escript mode.

Using Elixir `1.10.4-otp-23` and Erlang `23.0.3`.

Tested in `iex`:

```elixir
iex(1)> EscriptTestbed.CLI.main ~w(sync data_set_a)
Sync completed successfully:
<rest of the output omitted>
:ok

iex(2)> EscriptTestbed.CLI.main ~w(list)
Available scenarios:
- data_set_a
- data_set_b
:ok
```

Tested through escript:

```sh
$ make setup

$ make escript

$ ./escript_testbed sync data_set_a
Sync completed successfully:
- scenario: Elixir.EscriptTestbed.Scenarios.DataSetA
# <rest of the output omitted>

$ ./escript_testbed list
Available scenarios:
- data_set_a
- data_set_b
```